### PR TITLE
Fix path on case-sensitive filesystem

### DIFF
--- a/kentuckymule/src/main/scala/kentuckymule/ScalapHelper.scala
+++ b/kentuckymule/src/main/scala/kentuckymule/ScalapHelper.scala
@@ -150,7 +150,7 @@ object ScalapHelper {
       "sample-projects/scalap/scala/tools/scalap/scalax/rules/scalasig/Symbol.scala",
       "sample-projects/scalap/scala/tools/scalap/scalax/rules/scalasig/Type.scala",
       "sample-projects/scalap/scala/tools/scalap/scalax/rules/SeqRule.scala",
-      "sample-projects/scalap/scala/tools/scalap/scalax/Util/StringUtil.scala") map {
+      "sample-projects/scalap/scala/tools/scalap/scalax/util/StringUtil.scala") map {
       relativePath => projectDir.resolve(relativePath).toAbsolutePath.toString
     }
     sourcesFiles.toArray


### PR DESCRIPTION
Before this patch, running:
  scala -cp kentuckyMule.jar kentuckymule.Main
on Linux failed with:
error: not found: sample-projects/scalap/scala/tools/scalap/scalax/Util/StringUtil.scala