### PR TITLE
Add Tuple type resolution

### DIFF
--- a/kentuckymule/src/main/scala/kentuckymule/core/Types.scala
+++ b/kentuckymule/src/main/scala/kentuckymule/core/Types.scala
@@ -78,6 +78,11 @@ object Types {
     override def lookup(name: Name)(implicit contexts: Context): Symbol = tpe.lookup(name)
   }
 
+  final case class TupleType(types: Array[Type]) extends TypeType {
+    override def typeSymbol: Symbol = NoSymbol
+    override def lookup(name: Name)(implicit contexts: Context): Symbol = NoSymbol
+  }
+
   case object InferredTypeMarker extends Type {
     override def typeSymbol: Symbol = NoSymbol
     override def lookup(name: Name)(implicit contexts: Context): Symbol = NoSymbol


### PR DESCRIPTION
This adds a new TupleType to the core.Types to allow compiling tuples in
various cases: constructors, type parameters, return types, method
parameters.

`Tuple` is an interesting type, since it is unnamed, yet the type is the ordered
types of its make-up. I imagine this could be further sped up if we added a
step to turn a raw `untpd.Tuple` into a `TupleN[A, ... A']` class before
resolution. I'm just not that familiar, yet, with the code base.